### PR TITLE
user username instead of fullname for course enrollment and unenrollment

### DIFF
--- a/openedx/features/lumsx_features/tasks.py
+++ b/openedx/features/lumsx_features/tasks.py
@@ -38,7 +38,7 @@ def send_course_enrollment_email_for_user(self, site_id, user_id, course_id, mes
             'request': request,
             'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             'site_name': configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME),
-            'full_name': user.get_full_name(),
+            'username': user.username,
             'course_name': course.display_name,
             'course_url': '{protocol}://{site}{link}'.format(
                 protocol='https' if request.is_secure() else 'http',

--- a/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseenrollment/email/body.html
+++ b/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseenrollment/email/body.html
@@ -21,7 +21,7 @@
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
 
             <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
+                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ username }}{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseenrollment/email/body.txt
+++ b/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseenrollment/email/body.txt
@@ -1,9 +1,9 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{% blocktrans %}Dear {{ username }}{% endblocktrans %}
 
 {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }}. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
 
 {% blocktrans %}To start accessing course materials, please visit {{ course_url }}{% endblocktrans %}
 
 ----
-{% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
+{% blocktrans %}This email was automatically sent from {{ site_name }} to {{ username }}{% endblocktrans %}
 {% endautoescape %}

--- a/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseunenrollment/email/body.html
+++ b/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseunenrollment/email/body.html
@@ -23,7 +23,7 @@
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
+                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ username }}{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseunenrollment/email/body.txt
+++ b/openedx/features/lumsx_features/templates/lumsx_features/edx_ace/courseunenrollment/email/body.txt
@@ -1,8 +1,8 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{% blocktrans %}Dear {{ username }}{% endblocktrans %}
 
 {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }}. This course will no longer appear on your {{ site_name }} dashboard.{% endblocktrans %}
 
 {% blocktrans %}Your other courses have not been affected.{% endblocktrans %}
 
 ----
-{% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}{% endautoescape %}
+{% blocktrans %}This email was automatically sent from {{ site_name }} to {{ username }}{% endblocktrans %}{% endautoescape %}


### PR DESCRIPTION
## Ticket
[https://edlyio.atlassian.net/browse/LUMS-7](https://edlyio.atlassian.net/browse/LUMS-7)

## Description
user's fullname may or may not be empty that is why using username