### PR TITLE
redirect anonymous user to signin page when config or feature flag is on

### DIFF
--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 """Tests of Branding API views. """
+import copy
 import json
 import urllib
 
@@ -315,3 +316,26 @@ class TestIndex(SiteMixin, TestCase):
         self.client.login(username=self.user.username, password="password")
         response = self.client.get(reverse("dashboard"))
         self.assertIn(self.site_configuration_other.values["MKTG_URLS"]["ROOT"], response.content)
+
+    def test_index_redirects_to_signin_with_site_override(self):
+        """ Test index view redirects if ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER is set in SiteConfiguration """
+        self.use_site(self.site_for_signin_redirection)
+        response = self.client.get(reverse("root"))
+        self.assertRedirects(
+            response,
+            reverse('signin_user'),
+            fetch_redirect_response=False
+        )
+
+    def test_index_redirects_to_signin_with_feature_flag(self):
+        """ Test index view redirects if ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER feature flag is set """
+        self.use_site(self.site_for_signin_redirection)
+        feature_flags = copy.deepcopy(settings.FEATURES)
+        feature_flags['ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER'] = True
+        with self.settings(FEATURES=feature_flags):
+            response = self.client.get(reverse("root"))
+            self.assertRedirects(
+                response,
+                reverse('signin_user'),
+                fetch_redirect_response=False
+            )

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -52,6 +52,12 @@ def index(request):
             req_new['next'] = reverse('dashboard')
             request.GET = req_new
         return ssl_login(request)
+    
+    if request.user.is_anonymous:
+        if configuration_helpers.get_value(
+                'ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER',
+                settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER', False)):
+            return redirect(reverse('signin_user'))
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',

--- a/openedx/core/djangoapps/site_configuration/tests/mixins.py
+++ b/openedx/core/djangoapps/site_configuration/tests/mixins.py
@@ -41,6 +41,18 @@ class SiteMixin(object):
             }
         )
 
+        self.site_for_signin_redirection = SiteFactory.create(
+            domain='fake.site.domain',
+            name='fake.site.name'
+        )
+        self.site_configuration_for_signin_redirection = SiteConfigurationFactory.create(
+            site=self.site_for_signin_redirection,
+            values={
+                "SITE_NAME": self.site_for_signin_redirection.domain,
+                "ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER": True,
+            }
+        )
+
         # Initialize client with default site domain
         self.use_site(self.site)
 


### PR DESCRIPTION
**Description:** 
redirect the anonymous user to the sign-in page when root/homepage is hit

**JIRA:** 
[https://edlyio.atlassian.net/browse/LUMS-64](https://edlyio.atlassian.net/browse/LUMS-64)

**Testing instructions:**

1. Set `ALWAYS_REDIRECT_HOMEPAGE_TO_SIGNIN_FOR_ANONYMOUS_USER` feature flag/site config to True
2. Hit homepage
3. user will be redirected to the sign-in page

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
